### PR TITLE
Fix ffmpeg path detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,29 @@
 # Music-Extractor
 
 A simple Python script to extract audio from video files using `ffmpeg`.
+If an `ffmpeg` executable is bundled with this project it will be used
+automatically. Place the binary either next to the Python files or inside an
+`ffmpeg` folder. Otherwise the system `ffmpeg` on `PATH` is required.
 
 ## Requirements
 - Python 3.10+
-- `ffmpeg` installed and available on the system PATH
+- `ffmpeg` available either in the project folder or on the system PATH
 - Install Python dependencies with `pip install -r requirements.txt`
 
 ## Usage
-Run the script specifying an input video file and the desired output audio file.
-The output file extension determines the format. Optionally set the codec via
-`--codec`.
+Run the script specifying an input video file. By default the audio will be
+written to the same folder using the selected codec. You may pass an explicit
+output file or a target directory with `--output-dir`. The output file
+extension determines the format. Optionally set the codec via `--codec`.
 
 ```bash
-python extract_audio.py input.mp4 output.mp3
+python extract_audio.py input.mp4
+```
+
+Explicit output location:
+
+```bash
+python extract_audio.py input.mov --output-dir /tmp --codec vorbis
 ```
 
 Example with explicit codec:
@@ -23,6 +33,7 @@ python extract_audio.py input.mov output.ogg --codec vorbis
 ## Graphical Interface
 
 Run `python music_extractor_gui.py` for a minimal desktop interface. Use the
-buttons to pick input files and an output folder, choose the output format, and
-click **Run Extraction** to process each file. Progress messages will appear in
-the log window.
+buttons to pick input files and optionally an output folder, choose the output
+format, and click **Run Extraction** to process each file. Progress messages and
+the full ffmpeg log for each file will appear in the log window as well as in a
+`.txt` file alongside the extracted audio.

--- a/extract_audio.py
+++ b/extract_audio.py
@@ -1,41 +1,112 @@
 import argparse
 import subprocess
-import sys
+import shutil
 from pathlib import Path
 
-def extract_audio(input_file: Path, output_file: Path, codec: str = "mp3") -> None:
-    """Extracts audio from a video file using ffmpeg."""
+
+def find_ffmpeg() -> str:
+    """Return path to an ``ffmpeg`` executable preferring bundled copies."""
+    here = Path(__file__).resolve().parent
+    candidates = [
+        here / "ffmpeg",
+        here / "ffmpeg.exe",
+        here / "ffmpeg" / "ffmpeg",
+        here / "ffmpeg" / "ffmpeg.exe",
+        here / "ffmpeg" / "bin" / "ffmpeg",
+        here / "ffmpeg" / "bin" / "ffmpeg.exe",
+    ]
+    for path in candidates:
+        if path.exists():
+            return str(path)
+
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg:
+        return ffmpeg
+    raise FileNotFoundError("ffmpeg executable not found")
+
+def extract_audio(
+    input_file: Path,
+    output_file: Path,
+    codec: str = "mp3",
+    ffmpeg_path: str | Path | None = None,
+    log_file: Path | None = None,
+) -> str:
+    """Extract audio from a video or audio file using ffmpeg.
+
+    Parameters
+    ----------
+    input_file: Path
+        Source file to extract from.
+    output_file: Path
+        Path of the resulting audio file.
+    codec: str
+        Audio codec to use.
+    ffmpeg_path: str | Path | None
+        Optional explicit path to ffmpeg. If ``None`` a search is performed via
+        :func:`find_ffmpeg`.
+    log_file: Path | None
+        Path to a file where ffmpeg output will be written. Defaults to a ``.txt``
+        file alongside ``output_file``.
+
+    Returns
+    -------
+    str
+        ffmpeg's combined standard output and error.
+    """
     if not input_file.exists():
         raise FileNotFoundError(f"Input file {input_file} does not exist")
+
+    ffmpeg = str(ffmpeg_path or find_ffmpeg())
+
+    if log_file is None:
+        log_file = output_file.with_suffix(".txt")
+
     cmd = [
-        "ffmpeg",
+        ffmpeg,
         "-i",
         str(input_file),
         "-vn",
         "-acodec",
         codec,
-        str(output_file)
+        str(output_file),
     ]
     result = subprocess.run(cmd, capture_output=True, text=True)
+
+    with open(log_file, "w", encoding="utf-8") as fh:
+        fh.write(result.stdout)
+        fh.write(result.stderr)
+
     if result.returncode != 0:
-        print(result.stderr, file=sys.stderr)
-        raise RuntimeError("ffmpeg failed")
+        raise RuntimeError(f"ffmpeg failed: {result.stderr}")
+
+    return result.stdout + result.stderr
 
 def main(argv=None):
     parser = argparse.ArgumentParser(description="Extract audio from video files")
     parser.add_argument("input", type=Path, help="Input video file")
-    parser.add_argument(
-        "output",
-        type=Path,
-        help="Output audio file. Extension determines format",
-    )
+    parser.add_argument("output", nargs="?", type=Path, help="Output audio file")
     parser.add_argument(
         "--codec",
         default="mp3",
         help="Audio codec to use (default: mp3)",
     )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Directory to place output file (default: same as input)",
+    )
     args = parser.parse_args(argv)
-    extract_audio(args.input, args.output, args.codec)
+
+    if args.output and args.output_dir:
+        parser.error("Specify either an output file or --output-dir, not both")
+
+    if args.output:
+        output_file = args.output
+    else:
+        directory = args.output_dir or args.input.parent
+        output_file = directory / f"{args.input.stem}.{args.codec}"
+
+    extract_audio(args.input, output_file, args.codec)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- handle ffmpeg packaged as folder or `.exe`
- document new search behaviour in README

## Testing
- `python -m py_compile extract_audio.py music_extractor_gui.py`
- `sudo apt-get update`
- `sudo apt-get install -y ffmpeg`
- `ffmpeg -f lavfi -i sine=frequency=1000:duration=1 -c:a mp3 test_input.mp3 -y`
- `mkdir -p out && python extract_audio.py test_input.mp3 --output-dir out`

------
https://chatgpt.com/codex/tasks/task_e_683fc0c96cd4832382276acdb3279f3f